### PR TITLE
fix peerDependencies syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": ""
+    "react": "*"
   },
   "devDependencies": {
     "nwb": "0.14.x",


### PR DESCRIPTION
Hi @jogoodma ,

I ran into a minor issue with peerDependencies when installing the ribbon component. Even though `"react": ""` is supposed to be valid syntax, it causes a npm warning due to not matching the version of react I have installed. So here I'd like to change the peerDependencies clause to the equivalent syntax `"react": "*"`, which works for me.

Here is the NPM warning I got (I'm using the latest long-term support version of node (v6.10.2) and npm (3.10.10)):
```
├── UNMET PEER DEPENDENCY react@15.5.4
└── react-ontology-ribbon@0.1.1

npm WARN react-ontology-ribbon@0.1.1 requires a peer of react@ but none was installed.
```

Thank you!